### PR TITLE
ci: Add workflow to sync .clang-format

### DIFF
--- a/.github/workflows/format_file_check.yml
+++ b/.github/workflows/format_file_check.yml
@@ -1,0 +1,68 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Sync clang-format
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  sync:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+
+    if: github.event.repository.fork == true
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v4
+
+      - name: Download .clang-format from source
+        run: |
+          wget -O .clang-format-core https://raw.githubusercontent.com/apache/mynewt-core/refs/heads/master/.clang-format
+
+      - name: Check for changes & replace
+        id: changed
+        run: |
+          if ! cmp -s ".clang-format-core" ".clang-format"; then
+            echo "🔄 .clang-format has changed, updating..."
+            diff -u .clang-format .clang-format-core
+            mv .clang-format-core .clang-format
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ No changes detected."
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.changed.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          author: Mynewt Bot <dev@mynewt.apache.org>
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            ci: Update .clang-format from apache-mynewt-core
+          branch: update-clang-format
+          title: "Update clang format"
+          body: |
+            Syncing the latest .clang-format file from apache-mynewt-core
+
+            [1]: https://github.com/peter-evans/create-pull-request


### PR DESCRIPTION
If changes are detected, it updates the local file and automatically opens a pull request on the current repository to apply the update.

This ensures consistent and up-to-date code formatting configuration.

Uses:
- GitHub Actions with cron trigger (daily at 06:00 UTC)
- peter-evans/create-pull-request@v7 for automated PR creation

[1]: https://github.com/peter-evans/create-pull-request